### PR TITLE
 Update the installation command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ brew install rs/tap/dnstrace
 From source:
 
 ```
-go get github.com/rs/dnstrace
+go install github.com/rs/dnstrace@latest
 ```
 
 Or download a [binary package](https://github.com/rs/dnstrace/releases/latest).


### PR DESCRIPTION
'go get' is no longer supported outside a module. So I change the installation command to "go install github.com/rs/dnstrace@latest" in README.md.